### PR TITLE
Fix link to imagej.net page 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ bUnwarpJ
 
 2D Image registration method based on elastic deformations represented by B-splines. The invertibility of the deformations is forced through a consistency restriction.
 
-For all details, visit the home page at [bUnwarpJ](http://imagej.net/bUnwarpJ/).
+For all details, visit the home page at [bUnwarpJ](http://imagej.net/BUnwarpJ).


### PR DESCRIPTION
Fix link to imagej.net page: http://imagej.net/BUnwarpJ

> Wiki pages are case-sensitive and must start with a number or upper-case letter 

according to http://imagej.net/404
